### PR TITLE
Missing dependency.

### DIFF
--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -5,3 +5,4 @@ include_directories("${CUDD_UTIL_DIR}")
 include_directories("${CUDD_SOURCE_DIR}")
 
 add_library(obj "${CMAKE_CURRENT_SOURCE_DIR}/cuddObj.cc")
+target_link_libraries(obj cudd)


### PR DESCRIPTION
Library `obj` depends on `cudd`. This becomes necessary when linking using position independent code.
